### PR TITLE
Fix scoping issues

### DIFF
--- a/lua/lualine/themes/deepwhite.lua
+++ b/lua/lualine/themes/deepwhite.lua
@@ -1,8 +1,18 @@
 local config = require("deepwhite.config")
 local colors = require("deepwhite.colors").get_colors(config.options)
 
--- vim.opt.fillchars:append({ stl = "─", stlnc = "─" })
+--[[--Why do we have to do this?--
+  You might think we could do the following:
 
+    vim.opt.fillchars:append({ stl = "─", stlnc = "─" })
+
+  However, this has a problem: it will update both the local and global values
+  of fillchar, and in particular, the local value will override the global
+  value.
+
+  To avoid this behavior, we have to explicitly specify the scope---local or
+  global---when setting an option value.
+]]
 function set_option_safe(name, setter)
     for scope in {"local", "global"} do
         local scoped_value = vim.api.nvim_get_option_value(name, {scope = scope})

--- a/lua/lualine/themes/deepwhite.lua
+++ b/lua/lualine/themes/deepwhite.lua
@@ -1,6 +1,15 @@
 local config = require("deepwhite.config")
 local colors = require("deepwhite.colors").get_colors(config.options)
-vim.opt.fillchars:append({ stl = "─", stlnc = "─" })
+
+-- vim.opt.fillchars:append({ stl = "─", stlnc = "─" })
+
+function set_option_safe(name, setter)
+    for scope in {"local", "global"} do
+        local scoped_value = vim.api.nvim_get_option_value(name, {scope = scope})
+        vim.api.nvim_set_option_value(name, setter(scoped_value), { scope = scope })
+    end
+end
+set_option_safe("fillchars", function (fcs) { stl = "─", stlnc = "─", table.unpack(fcs) } end)
 
 return {
 	visual = {


### PR DESCRIPTION
I had an issue where changing the colorscheme to deepwhite would break my fillchars, so I managed to trace it back to here and fix it.

(See https://github.com/folke/zen-mode.nvim/pull/109)