### PR TITLE
DapUI Colors

### DIFF
--- a/lua/deepwhite/colors.lua
+++ b/lua/deepwhite/colors.lua
@@ -29,10 +29,7 @@ function M.get_colors(options)
 		pink = "#A6006F", -- hsv(320, 100%, 65%)
 		red = "#A60000", -- hsv(360, 100%, 65%)
 
-		foam = '#56949f',
 		iris = '#907aa9',
-		love = '#b4637a',
-		gold = '#ea9d34',
 		muted = '#9893a5',
 	}
 	if options.low_blue_light then

--- a/lua/deepwhite/colors.lua
+++ b/lua/deepwhite/colors.lua
@@ -28,6 +28,12 @@ function M.get_colors(options)
 		purple = "#6F00A6", -- hsv(280, 100%, 65%)
 		pink = "#A6006F", -- hsv(320, 100%, 65%)
 		red = "#A60000", -- hsv(360, 100%, 65%)
+
+		foam = '#56949f',
+		iris = '#907aa9',
+		love = '#b4637a',
+		gold = '#ea9d34',
+		muted = '#9893a5',
 	}
 	if options.low_blue_light then
 		colors.base7 = "#FAFAFA" -- hsv(60, 0%, 98%)

--- a/lua/deepwhite/scheme.lua
+++ b/lua/deepwhite/scheme.lua
@@ -387,6 +387,27 @@ function M.get_groups(c)
 		SelectMode = { link = "VisualMode" },
 		TerminalMode = { link = "NormalMode" },
 		TerminalNormalMode = { link = "NormalMode" },
+
+		-- rcarriga/nvim-dap-ui
+		DapUIVariable = { link = 'Normal' },
+		DapUIValue = { link = 'Normal' },
+		DapUIFrameName = { link = 'Normal' },
+		DapUIThread = { fg = c.orange },
+		DapUIWatchesValue = { link = 'DapUIThread' },
+		DapUIBreakpointsInfo = { link = 'DapUIThread' },
+		DapUIBreakpointsCurrentLine = { fg = c.orange, bold = True },
+		-- DapUIWatchesEmpty = { fg = c.love },
+		DapUIWatchesError = { link = 'DapUIWatchesEmpty' },
+		DapUIBreakpointsDisabledLine = { fg = c.muted },
+		DapUISource = { fg = c.iris },
+		DapUIBreakpointsPath = { fg = c.cyan },
+		DapUIScope = { link = 'DapUIBreakpointsPath' },
+		DapUILineNumber = { link = 'DapUIBreakpointsPath' },
+		DapUIBreakpointsLine = { link = 'DapUIBreakpointsPath' },
+		DapUIFloatBorder = { link = 'DapUIBreakpointsPath' },
+		DapUIStoppedThread = { link = 'DapUIBreakpointsPath' },
+		DapUIDecoration = { link = 'DapUIBreakpointsPath' },
+		DapUIModifiedValue = { fg = c.cyan, bold = True },
 	}
 end
 

--- a/lua/deepwhite/scheme.lua
+++ b/lua/deepwhite/scheme.lua
@@ -396,7 +396,6 @@ function M.get_groups(c)
 		DapUIWatchesValue = { link = 'DapUIThread' },
 		DapUIBreakpointsInfo = { link = 'DapUIThread' },
 		DapUIBreakpointsCurrentLine = { fg = c.orange, bold = True },
-		-- DapUIWatchesEmpty = { fg = c.love },
 		DapUIWatchesError = { link = 'DapUIWatchesEmpty' },
 		DapUIBreakpointsDisabledLine = { fg = c.muted },
 		DapUISource = { fg = c.iris },


### PR DESCRIPTION
Makes DapUI Colors readable 
took this as an example: https://github.com/rose-pine/neovim/pull/87

**before**
![image](https://github.com/user-attachments/assets/eb73c734-5019-49af-99f6-0b02dba14512)

**after**
![image](https://github.com/user-attachments/assets/25b28e51-df35-4d16-b061-6499304ba084)
